### PR TITLE
🐛(app) remove the unnecessary dependency "pins"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- remove the unnecessary dependency "pins"
+
 ## [0.1.0] - 2023-10-30
 
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,13 +32,12 @@ requires_python = >=3.8
 [options]
 install_requires =
     django>=3.2,<4.3
-    djangorestframework==3.14
-    ffmpeg-python==0.2.0
-    python-socketio==5.9
-    django-storages==1.13.2
-    boto3==1.28.42
-    shortuuid==1.0.0
-    websockets==11.0.3
+    djangorestframework>=3,<4
+    ffmpeg-python>=0.2.0,<1
+    python-socketio>=5,<6
+    django-storages>=1,<2
+    boto3>=1.9,<2
+    websockets>=11,<12
 
 include_package_data = true
 packages = find:

--- a/tests/app/video.py
+++ b/tests/app/video.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-import shortuuid
 
 from django_peertube_runner_connector.models import Video
 from django_peertube_runner_connector.serializers import RunnerJobSerializer
@@ -50,7 +49,6 @@ class TestVideoViewSet(viewsets.GenericViewSet):
             {
                 "video": {
                     "id": video.id,
-                    "shortUUID": shortuuid.uuid(str(video.uuid)),
                     "uuid": video.uuid,
                 }
             }
@@ -72,7 +70,6 @@ class TestVideoViewSet(viewsets.GenericViewSet):
             {
                 "video": {
                     "id": video.id,
-                    "shortUUID": shortuuid.uuid(str(video.uuid)),
                     "uuid": video.uuid,
                 }
             }


### PR DESCRIPTION
## Purpose

The dependency "pins" are too restrictive and are causing issues to other apps that are using the same dependencies but with different versions.

## Proposal

- [x] remove pin and use range to dependencies versions
