### PR TITLE
🐛(app) add options in videos storage settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Changed
+
+- Add settings options for "videos" storages
+
 ## [0.2.0] - 2023-11-08
 
 ### Fixed

--- a/src/django_peertube_runner_connector/storage.py
+++ b/src/django_peertube_runner_connector/storage.py
@@ -8,9 +8,11 @@ class ConfiguredStorage(LazyObject):
     """Lazy object for the video storage."""
 
     def _setup(self):
-        self._wrapped = storage.get_storage_class(
-            settings.STORAGES["videos"]["BACKEND"]
-        )()
+        """Setup the video storage."""
+        params = settings.STORAGES["videos"]
+        backend = params.pop("BACKEND")
+        options = params.pop("OPTIONS", {})
+        self._wrapped = storage.get_storage_class(backend)(**options)
 
 
 video_storage = ConfiguredStorage()


### PR DESCRIPTION
## Purpose

We want to not be forced to create a new storage class to give it options.

## Proposal

Add settings options for "videos" storages

- [x] Give settings options to storage class when instantiating it.

