### PR TITLE
🐛(app) fix video storage removing settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Fixed
+
+- videos storage does not remove settings
+
 ## [0.3.0] - 2023-11-15
 
 ## Changed

--- a/src/django_peertube_runner_connector/storage.py
+++ b/src/django_peertube_runner_connector/storage.py
@@ -10,8 +10,8 @@ class ConfiguredStorage(LazyObject):
     def _setup(self):
         """Setup the video storage."""
         params = settings.STORAGES["videos"]
-        backend = params.pop("BACKEND")
-        options = params.pop("OPTIONS", {})
+        backend = params.get("BACKEND")
+        options = params.get("OPTIONS", {})
         self._wrapped = storage.get_storage_class(backend)(**options)
 
 

--- a/tests/tests_django_peertube_runner_connector/test_storage.py
+++ b/tests/tests_django_peertube_runner_connector/test_storage.py
@@ -1,0 +1,36 @@
+"""Test the storage file."""
+import tempfile
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+
+from django_peertube_runner_connector.storage import ConfiguredStorage
+
+
+class TestStorage(TestCase):
+    """Test the storage file."""
+
+    tempdir = tempfile.gettempdir()
+
+    @override_settings(
+        STORAGES={
+            "videos": {
+                "BACKEND": "django.core.files.storage.FileSystemStorage",
+                "OPTIONS": {"location": tempdir},
+            }
+        }
+    )
+    def test_storage_configuration(self):
+        """Calling several times the storage should not affect his options ."""
+        simple_file = SimpleUploadedFile(
+            "file.mp4", b"file_content", content_type="video/mp4"
+        )
+        storage = ConfiguredStorage()
+
+        storage.save("random_file", simple_file)
+        self.assertTrue(storage.exists("random_file"))
+        self.assertEqual(storage.path("random_file"), f"{self.tempdir}/random_file")
+
+        storage = ConfiguredStorage()
+        self.assertTrue(storage.exists("random_file"))
+        self.assertEqual(storage.path("random_file"), f"{self.tempdir}/random_file")


### PR DESCRIPTION
Using .pop() on a dict remove the key and return the value. So the settings were removed from the settings dict and the video storage could not be used anymore. Instead we should use .get()