### PR TITLE
🐛(app) fix crash when probe properties are not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Fixed
+
+- Crash when properties were missing from probe
+
 ## [0.4.0] - 2023-12-14
 
 ## Added

--- a/src/django_peertube_runner_connector/utils/ffprobe.py
+++ b/src/django_peertube_runner_connector/utils/ffprobe.py
@@ -28,12 +28,14 @@ def get_video_stream_dimensions_info(path: str, existing_probe=None):
     """Return the video stream dimensions info."""
 
     if video_stream := get_video_stream(path=path, existing_probe=existing_probe):
+        min_dimension = min(video_stream["height"], video_stream["width"])
+        max_dimension = max(video_stream["height"], video_stream["width"])
+
         return {
             "width": video_stream["width"],
             "height": video_stream["height"],
-            "ratio": max(video_stream["height"], video_stream["width"])
-            / min(video_stream["height"], video_stream["width"]),
-            "resolution": min(video_stream["height"], video_stream["width"]),
+            "ratio": max_dimension / min_dimension if min_dimension > 0 else 0,
+            "resolution": min_dimension,
             "isPortraitMode": video_stream["height"] > video_stream["width"],
         }
 
@@ -139,7 +141,7 @@ def get_audio_stream(path, existing_probe=None):
         return {
             "absolute_path": probe["format"]["filename"],
             "audio_stream": audio_stream,
-            "bitrate": int(audio_stream.get("bit_rate")),
+            "bitrate": int(audio_stream.get("bit_rate", 0)),
         }
 
     return {"absolute_path": probe["format"]["filename"]}

--- a/src/django_peertube_runner_connector/views/runner_job.py
+++ b/src/django_peertube_runner_connector/views/runner_job.py
@@ -123,18 +123,20 @@ class RunnerJobViewSet(viewsets.GenericViewSet):
     def error_runner_job(self, request, uuid=None):
         """Endpoint to signal an error with a job."""
         runner = self._get_runner_from_token(request)
+        message = request.data.get("message")
         job = self._get_job_from_uuid(uuid)
         job.failures += 1
 
         logger.error(
-            "Remote runner %s had an error with job %s (%s)",
+            "Remote runner %s had an error with job %s (%s): %s",
             runner.name,
             job.uuid,
             job.type,
+            message,
         )
 
         runner_job_handler = get_runner_job_handler_class(job)
-        runner_job_handler().error(runner_job=job, message=request.data.get("message"))
+        runner_job_handler().error(runner_job=job, message=message)
 
         runner.update_last_contact(get_client_ip(request))
 

--- a/tests/tests_django_peertube_runner_connector/utils/test_ffprobe.py
+++ b/tests/tests_django_peertube_runner_connector/utils/test_ffprobe.py
@@ -45,6 +45,28 @@ class TestFFProbe(TestCase):
         self.assertEqual(dimensions_info["resolution"], 540)
         self.assertFalse(dimensions_info["isPortraitMode"])
 
+    def test_get_video_stream_dimensions_info_with_one_dimension(self):
+        """Should return the video stream dimensions info."""
+
+        dimensions_info = get_video_stream_dimensions_info(
+            "/path/to/video.mp4",
+            existing_probe={
+                "streams": [
+                    {
+                        "codec_type": "video",
+                        "height": 0,
+                        "width": 1900,
+                    }
+                ]
+            },
+        )
+
+        self.assertEqual(dimensions_info["width"], 1900)
+        self.assertEqual(dimensions_info["height"], 0)
+        self.assertEqual(dimensions_info["ratio"], 0)
+        self.assertEqual(dimensions_info["resolution"], 0)
+        self.assertFalse(dimensions_info["isPortraitMode"])
+
     def test_get_video_stream_fps(self):
         """Should return the video stream fps."""
         fps = get_video_stream_fps(probe_response)
@@ -83,10 +105,6 @@ class TestFFProbe(TestCase):
         )
 
         self.assertEqual(
-            audio_stream["absolute_path"],
-            "/path/to/audio.mp3",
-        )
-        self.assertEqual(
             audio_stream["audio_stream"],
             {
                 "bit_rate": "1066073",
@@ -99,7 +117,46 @@ class TestFFProbe(TestCase):
                 "tags": {"language": "eng"},
             },
         )
+        self.assertEqual(audio_stream["absolute_path"], "/path/to/audio.mp3")
         self.assertEqual(audio_stream["bitrate"], 1066073)
+
+    def test_get_audio_stream_without_bitrate(self):
+        """Should return the audio stream with bitrate set to 0."""
+
+        audio_stream = get_audio_stream(
+            "/path/to/audio.mp3",
+            existing_probe={
+                "streams": [
+                    {
+                        "codec_type": "audio",
+                        "channels": 2,
+                        "codec_name": "aac",
+                        "duration": "00:01:00.00",
+                        "index": 1,
+                        "sample_rate": "48000 Hz",
+                        "tags": {"language": "eng"},
+                    }
+                ],
+                "format": {
+                    "filename": "/path/to/audio.mp3",
+                },
+            },
+        )
+
+        self.assertEqual(
+            audio_stream["audio_stream"],
+            {
+                "channels": 2,
+                "codec_name": "aac",
+                "codec_type": "audio",
+                "duration": "00:01:00.00",
+                "index": 1,
+                "sample_rate": "48000 Hz",
+                "tags": {"language": "eng"},
+            },
+        )
+        self.assertEqual(audio_stream["absolute_path"], "/path/to/audio.mp3")
+        self.assertEqual(audio_stream["bitrate"], 0)
 
     def test_build_file_metadata(self):
         """Should return a dic with the file metadata."""


### PR DESCRIPTION
## Purpose

A crash happens when trying to get the bitrate of a not existing audio bitrate.

## Proposal

Handling every properties from ffprobe output with default values to prevent crashes. 
