### PR TITLE
✨(socketio) allow to use a client_manager with socketio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Added
+
+- Instantiate a redis manager for socketio
+
 ## [0.5.0] - 2023-12-21
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -197,6 +197,20 @@ from django_peertube_runner_connector.urls import (
 urlpatterns += django_peertube_runner_connector_urls
 ```
 
+If your application is distributed on multiple servers, you will probably need
+to use a message queue. We manage redis and redis sentinel manager. For this,
+you have to define this settings
+
+#### Redis sentinel
+
+- `DJANGO_PEERTUBE_RUNNER_CONNECTOR_SENTINELS`: A list of sentinel nodes. 
+Each node is represented by a pair (hostname, port). Example: [('localhost', 26379)]
+- `DJANGO_PEERTUBE_RUNNER_CONNECTOR_SENTINELS_MASTER`: The master sentinel name. Example: mymaster
+
+#### Redis
+
+- `DJANGO_PEERTUBE_RUNNER_CONNECTOR_REDIS`: The redis url. Example: `redis://localhost:6379`
+
 Voilà! Your server should be ready!
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     django-storages>=1,<2
     boto3>=1.9,<2
     websockets>=11,<12
+    redis>=5.0.0,<6
 
 include_package_data = true
 packages = find:

--- a/src/django_peertube_runner_connector/socketio/manager.py
+++ b/src/django_peertube_runner_connector/socketio/manager.py
@@ -1,0 +1,91 @@
+"""Module to manage a sentinel redis manager sor adyncio."""
+from django.conf import settings
+
+from redis.asyncio.sentinel import Sentinel
+from socketio import AsyncRedisManager
+
+
+def get_client_manager(write_only=False):
+    """
+    A factory responsible a correct redis manager based on the settings defined in the project.
+
+    To return a sentinel redis manager, the settings DJANGO_PEERTUBE_RUNNER_CONNECTOR_SENTINELS
+    and DJANGO_PEERTUBE_RUNNER_CONNECTOR_SENTINELS_MASTER must be defined.
+
+    To return a redis manager, the settings DJANGO_PEERTUBE_RUNNER_CONNECTOR_REDIS must be defined.
+
+    If none of these settings are defined, no manager will be created and the value None
+    will be return.
+    """
+    client_manager = None
+    if hasattr(settings, "DJANGO_PEERTUBE_RUNNER_CONNECTOR_SENTINELS"):
+        client_manager = AsyncSentinelRedisManager(
+            sentinels=settings.DJANGO_PEERTUBE_RUNNER_CONNECTOR_SENTINELS,
+            master=settings.DJANGO_PEERTUBE_RUNNER_CONNECTOR_SENTINELS_MASTER,
+            write_only=write_only,
+        )
+
+    if hasattr(settings, "DJANGO_PEERTUBE_RUNNER_CONNECTOR_REDIS"):
+        client_manager = AsyncRedisManager(
+            settings.DJANGO_PEERTUBE_RUNNER_CONNECTOR_REDIS, write_only=write_only
+        )
+
+    return client_manager
+
+
+class AsyncSentinelRedisManager(AsyncRedisManager):
+    """Redis sentinel based client manager for asyncio servers.
+
+    This class implements a Redis sentinel backend for event sharing across multiple
+    processes.
+
+    To use a Redis backend, initialize the :class:`AsyncServer` instance as
+    follows::
+
+        sentinels = [('localhost', 26379)]
+        master = 'mymaster'
+        client_manager = AsyncSentinelRedisManager(
+            sentinels=sentinels,
+            master=master
+        )
+        server = socketio.AsyncServer(client_manager=client_manager)
+
+    :param sentinels: A list of sentinel nodes.
+                      Each node is represented by a pair (hostname, port).
+                      Default: [('localhost', 26379)]
+    :param master: The master sentinel name. Default: mymaster
+    :param channel: The channel name on which the server sends and receives
+                    notifications. Must be the same in all the servers.
+    :param write_only: If set to ``True``, only initialize to emit events. The
+                       default of ``False`` initializes the class for emitting
+                       and receiving.
+    :param logger: To enable logging set to ``True`` or pass a logger object to
+                   use. To disable logging set to ``False``. Note that fatal
+                   errors are logged even when ``logger`` is ``False``.
+    :param redis_options: additional keyword arguments to be passed to
+                          ``aioredis.from_url()``.
+    """
+
+    name = "aioredis"
+
+    def __init__(
+        self,
+        sentinels=None,
+        master="mymaster",
+        channel="socketio",
+        write_only=False,
+        logger=None,
+        redis_options=None,
+    ):
+        if sentinels is None:
+            sentinels = [("localhost", 26379)]
+        self.sentinels = sentinels
+        self.master = master
+        self.redis_options = redis_options
+        self._redis_connect()
+        super().__init__(channel=channel, write_only=write_only, logger=logger)
+
+    def _redis_connect(self):
+        sentinel = Sentinel(self.sentinels, sentinel_kwargs=self.redis_options)
+        self.redis = sentinel.master_for(self.master)
+        self.pubsub = self.redis.pubsub(ignore_subscribe_messages=True)

--- a/tests/tests_django_peertube_runner_connector/test_socket.py
+++ b/tests/tests_django_peertube_runner_connector/test_socket.py
@@ -1,7 +1,7 @@
 """Tests for the "socket.py" file of the django_peertube_runner_connector app"""
-from unittest.mock import AsyncMock, patch
+from unittest import mock
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from django_peertube_runner_connector.factories import RunnerFactory
 from django_peertube_runner_connector.socket import (
@@ -18,8 +18,8 @@ class TestSocket(TestCase):
         """Create a video."""
         self.runner = RunnerFactory()
 
-    @patch("django_peertube_runner_connector.socket.logger")
-    @patch("django_peertube_runner_connector.socket.sio")
+    @mock.patch("django_peertube_runner_connector.socket.logger")
+    @mock.patch("django_peertube_runner_connector.socket.sio")
     async def test_socket_connect(self, _mock_sio, mock_logger):
         """Known runner should be able to connect to the server."""
         await connect(45115, None, {"runnerToken": self.runner.runnerToken})
@@ -28,8 +28,10 @@ class TestSocket(TestCase):
             "Runner with token %s connected with sid %s", self.runner.runnerToken, 45115
         )
 
-    @patch("django_peertube_runner_connector.socket.logger")
-    @patch("django_peertube_runner_connector.socket.sio", new_callable=AsyncMock)
+    @mock.patch("django_peertube_runner_connector.socket.logger")
+    @mock.patch(
+        "django_peertube_runner_connector.socket.sio", new_callable=mock.AsyncMock
+    )
     async def test_socket_connect_wrong_runner_token(self, mock_sio, mock_logger):
         """Known runner should be able to connect to the server."""
         await connect(45115, None, {"runnerToken": "Wrong Runner Token"})
@@ -39,17 +41,68 @@ class TestSocket(TestCase):
         )
         mock_sio.disconnect.assert_called_with(45115, namespace="/runners")
 
-    @patch("django_peertube_runner_connector.socket.logger")
-    @patch("django_peertube_runner_connector.socket.sio", new_callable=AsyncMock)
+    @mock.patch("django_peertube_runner_connector.socket.logger")
+    @mock.patch(
+        "django_peertube_runner_connector.socket.sio", new_callable=mock.AsyncMock
+    )
     async def test_socket_disconnect(self, _mock_sio, mock_logger):
         """Known runner should be able to connect to the server."""
         await disconnect(45115)
 
         mock_logger.info.assert_called_with("%s disconnected", 45115)
 
-    @patch("django_peertube_runner_connector.socket.sio", new_callable=AsyncMock)
-    async def test_socket_send_available_jobs_ping(self, mock_sio):
-        """Known runner should be able to connect to the server."""
+    @mock.patch(
+        "django_peertube_runner_connector.socket.sio", new_callable=mock.AsyncMock
+    )
+    async def test_socket_send_available_jobs_ping_with_no_manager(self, mock_sio):
+        """server with no manager should directly use sio to emit a message."""
         await send_available_jobs_ping_to_runners()
 
         mock_sio.emit.assert_called_with("available-jobs", namespace="/runners")
+
+    @mock.patch(
+        "django_peertube_runner_connector.socket.sio", new_callable=mock.AsyncMock
+    )
+    @override_settings(
+        DJANGO_PEERTUBE_RUNNER_CONNECTOR_SENTINELS=[("localhost", 26379)]
+    )
+    @override_settings(DJANGO_PEERTUBE_RUNNER_CONNECTOR_SENTINELS_MASTER="mymaster")
+    async def test_socket_send_available_jobs_ping_with_sentinel_manager(
+        self, _mock_sio
+    ):
+        """
+        When a sentinel is used as client manager, this one should be used to emit a message
+        """
+        mock_manager = mock.AsyncMock()
+        mock_manager.emit = mock.AsyncMock()
+
+        with mock.patch(
+            "django_peertube_runner_connector.socketio.manager.AsyncSentinelRedisManager",
+            return_value=mock_manager,
+        ):
+            await send_available_jobs_ping_to_runners()
+
+        mock_manager.emit.assert_awaited_once_with(
+            "available-jobs", data=None, namespace="/runners"
+        )
+
+    @mock.patch(
+        "django_peertube_runner_connector.socket.sio", new_callable=mock.AsyncMock
+    )
+    @override_settings(
+        DJANGO_PEERTUBE_RUNNER_CONNECTOR_REDIS="redis://localhost:6379/0"
+    )
+    async def test_socket_send_available_jobs_ping_with_redis_manager(self, _mock_sio):
+        """When redis is used as client manager, this one should be used to emit a message"""
+        mock_manager = mock.AsyncMock()
+        mock_manager.emit = mock.AsyncMock()
+
+        with mock.patch(
+            "django_peertube_runner_connector.socketio.manager.AsyncRedisManager",
+            return_value=mock_manager,
+        ):
+            await send_available_jobs_ping_to_runners()
+
+        mock_manager.emit.assert_awaited_once_with(
+            "available-jobs", data=None, namespace="/runners"
+        )


### PR DESCRIPTION
## Purpose

In a distributed apps context, we must use a client_manager with socketio. We implement a sentinel manager as we are using it in FUN applications. Also, redis manager is managed.

## Proposal

- [x] allow to use a client_manager with socketio