### PR TITLE
✨(app) generate upload url

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,27 @@ from django_peertube_runner_connector.urls import (
 urlpatterns += django_peertube_runner_connector_urls
 ```
 
-Voilà! Your server should be ready!
+Voilà! Your server should be ready! 
+
+### Usage
+Now somewhere in your project, you can call the `transcode_video` function:
+
+```Python
+from django_peertube_runner_connector.transcode import transcode_video
+
+transcode_video(
+    # Path to the video file
+    file_path="/path/to/video.mp4",
+    # Destination directory for the transcoded files
+    destination="result/",
+    # Used to name the files in the destination directory
+    base_name="my_cat",
+    # The domain name used to construct the download / upload URL for peerTube runners
+    domain=domain,
+)
+```
+
+And the transcoding will start!
 
 
 ### Demo application

--- a/src/django_peertube_runner_connector/storage.py
+++ b/src/django_peertube_runner_connector/storage.py
@@ -1,6 +1,43 @@
 """Video storage for the Django Peertube Runner Connector app."""
 from django.core.files.storage import storages
+from django.urls import reverse
 from django.utils.functional import LazyObject
+
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+def get_video_storage_upload_url(key: str, domain: str):
+    """
+    Get the upload url for the given path.
+    It will use the settings callback if defined.
+    If the storage inherits from S3Boto3Storage, it will use the boto3 client.
+    The default generated upload url use this app as backend.
+
+    The return value is a dict with the following keys:
+    - url: the upload url
+    - fields: the form fields (it should always contains he 'key' field)
+    """
+
+    # pylint: disable=protected-access
+    if issubclass(type(video_storage._wrapped), S3Boto3Storage):
+        # Use the boto3 client to generate the upload url.
+        s3_client = video_storage.connection.meta.client
+        return s3_client.generate_presigned_post(
+            video_storage.bucket_name,
+            key,
+            Fields={"acl": "private"},
+            Conditions=[
+                [{"acl": "private"}],
+                ["content-length-range", 0, 2**30],
+            ],
+            ExpiresIn=24 * 60 * 60 * 7,  # 7 days
+        )
+
+    # Use this app to generate the upload url.
+    return {
+        "url": domain + reverse("runner-jobs-upload_video_file"),
+        "fields": {"key": key},
+    }
 
 
 class ConfiguredStorage(LazyObject):

--- a/src/django_peertube_runner_connector/utils/job_handlers/abstract_job_handler.py
+++ b/src/django_peertube_runner_connector/utils/job_handlers/abstract_job_handler.py
@@ -99,6 +99,7 @@ class AbstractJobHandler(ABC):
             self.specific_complete(runner_job, result_payload)
             runner_job.state = RunnerJobState.COMPLETED
         except Exception as err:  # pylint: disable=broad-except
+            print(err)
             runner_job.state = RunnerJobState.ERRORED
             runner_job.error = str(err)
 

--- a/src/django_peertube_runner_connector/views/runner_job.py
+++ b/src/django_peertube_runner_connector/views/runner_job.py
@@ -184,6 +184,23 @@ class RunnerJobViewSet(viewsets.GenericViewSet):
     @action(
         detail=False,
         methods=["post"],
+        url_path="upload_file",
+        url_name="upload_video_file",
+    )
+    def upload_video_file(self, request):
+        """Endpoint to upload a video file."""
+        runner = self._get_runner_from_token(request)
+        key = request.data.get("key")
+
+        logger.info("Saving file for runner %s", runner.name)
+
+        video_storage.save(key, request.data.get("file").file)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(
+        detail=False,
+        methods=["post"],
         url_path="files/videos/(?P<video_id>[^/.]+)/(?P<job_id>[^/.]+)/max-quality",
         url_name="download_video_file",
     )

--- a/tests/tests_django_peertube_runner_connector/utils/job_handlers/test_abstract_job_handler.py
+++ b/tests/tests_django_peertube_runner_connector/utils/job_handlers/test_abstract_job_handler.py
@@ -255,6 +255,7 @@ class TestAbstractJobHandler(TestCase):
         )
         handler.specific_abort.assert_not_called()
 
+    @override_settings(TRANSCODING_RUNNER_MAX_FAILURE=5)
     def test_error_with_abort_supported(self):
         """Should reset the state of the runner job."""
         handler = VODHLSTranscodingJobHandler()

--- a/tests/tests_django_peertube_runner_connector/views/runner_job/test_error_runner_job.py
+++ b/tests/tests_django_peertube_runner_connector/views/runner_job/test_error_runner_job.py
@@ -78,6 +78,7 @@ class ErrorRunnerJobAPITest(TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(TRANSCODING_RUNNER_MAX_FAILURE=5)
     def test_error_hls_job_no_limit_reached(self):
         """
         Should be able to error the processing HLS job.

--- a/tests/tests_django_peertube_runner_connector/views/runner_job/test_success_runner_job.py
+++ b/tests/tests_django_peertube_runner_connector/views/runner_job/test_success_runner_job.py
@@ -44,7 +44,28 @@ class SuccessRunnerJobAPITest(TestCase):
             runner=self.runner,
             type=job_type,
             uuid="02404b18-3c50-4929-af61-913f4df65e00",
-            payload={"output": {"resolution": "1080"}},
+            payload={
+                "output": {
+                    "resolution": "1080",
+                    "fps": "30",
+                    "playlistFileUrl": {
+                        "fields": {
+                            "key": (
+                                "video-02404b18-3c50-4929-af61-913f4df65e99/"
+                                "my_video_result.m3u8"
+                            )
+                        }
+                    },
+                    "videoFileUrl": {
+                        "fields": {
+                            "key": (
+                                "video-02404b18-3c50-4929-af61-913f4df65e99/"
+                                "my_video_result.mp4"
+                            )
+                        }
+                    },
+                }
+            },
             privatePayload={
                 "videoUUID": "02404b18-3c50-4929-af61-913f4df65e99",
                 "isNewVideo": True,
@@ -83,7 +104,18 @@ class SuccessRunnerJobAPITest(TestCase):
         uploaded_video = SimpleUploadedFile(
             "file.mp4", b"file_content", content_type="video/mp4"
         )
-        SimpleUploadedFile("file.m3u8", b"file_content", content_type="video/mp4")
+        playlist = SimpleUploadedFile(
+            "file.m3u8", b"file_content", content_type="application/x-mpegURL"
+        )
+
+        video_storage.save(
+            "video-02404b18-3c50-4929-af61-913f4df65e99/my_video_result.mp4",
+            uploaded_video,
+        )
+        video_storage.save(
+            "video-02404b18-3c50-4929-af61-913f4df65e99/my_video_result.m3u8",
+            playlist,
+        )
 
         now = datetime(2018, 8, 8, tzinfo=tz.utc)
 
@@ -94,8 +126,6 @@ class SuccessRunnerJobAPITest(TestCase):
                 "/api/v1/runners/jobs/02404b18-3c50-4929-af61-913f4df65e00/success",
                 data={
                     "runnerToken": "runnerToken",
-                    "payload[videoFile]": uploaded_video,
-                    "payload[resolutionPlaylistFile]": uploaded_video,
                 },
             )
             self.assertEqual(response.status_code, 204)

--- a/tests/tests_django_peertube_runner_connector/views/runner_job/test_upload_runner_job.py
+++ b/tests/tests_django_peertube_runner_connector/views/runner_job/test_upload_runner_job.py
@@ -1,0 +1,60 @@
+"""Tests for the Runner Job upload API."""
+import logging
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from django_peertube_runner_connector.factories import RunnerFactory, VideoFactory
+from django_peertube_runner_connector.storage import video_storage
+
+
+# We don't enforce arguments documentation in tests
+# pylint: disable=unused-argument
+
+
+class UploadRunnerJobAPITest(TestCase):
+    """Test for the Runner Job upload API."""
+
+    maxDiff = None
+
+    def setUp(self):
+        """Create a runner and a video."""
+        self.runner = RunnerFactory(name="New Runner", runnerToken="runnerToken")
+        self.video = VideoFactory(uuid="02404b18-3c50-4929-af61-913f4df65e99")
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        """restore logging"""
+        logging.disable(logging.NOTSET)
+
+    def test_upload_with_an_invalid_runner_token(self):
+        """Should not be able to upload with an invalid token."""
+        response = self.client.post(
+            "/api/v1/runners/jobs/upload_file",
+            data={
+                "runnerToken": "invalid_token",
+            },
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_success_hls_job_with_a_valid_runner_token(self):
+        """Should be able to upload a file."""
+        uploaded_video = SimpleUploadedFile(
+            "file.mp4", b"file_content", content_type="video/mp4"
+        )
+
+        response = self.client.post(
+            "/api/v1/runners/jobs/upload_file",
+            data={
+                "runnerToken": "runnerToken",
+                "key": "video-02404b18-3c50-4929-af61-913f4df65e89/my_video_result.mp4",
+                "file": uploaded_video,
+            },
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertTrue(
+            video_storage.exists(
+                "video-02404b18-3c50-4929-af61-913f4df65e89/my_video_result.mp4"
+            )
+        )


### PR DESCRIPTION
Add generated upload url when creating a runner_job. It will be used by the runner to upload the video. By default the upload endpoint is pointing to our app, but it the storage inherit from s3, then it will boto3 client to generate the upload url.

It should be used with this Peertube [PR](https://github.com/Chocobozzz/PeerTube/pull/6135). 