### PR TITLE
🐛(transcript) use video_url for unknown video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add a parameter to the transcode function to specify the source file
+
 ## [0.7.0] - 2024-08-28
 
 ### Added

--- a/src/django_peertube_runner_connector/transcript.py
+++ b/src/django_peertube_runner_connector/transcript.py
@@ -1,7 +1,7 @@
 """Base function to start the transcription process."""
 import logging
 
-from django_peertube_runner_connector.models import Video
+from django_peertube_runner_connector.models import Video, VideoState
 from django_peertube_runner_connector.utils.transcription.job_creation import (
     create_transcription_job,
 )
@@ -10,19 +10,25 @@ from django_peertube_runner_connector.utils.transcription.job_creation import (
 logger = logging.getLogger(__name__)
 
 
-def transcript_video(destination: str, domain: str):
+def transcript_video(destination: str, domain: str, video_url: str = None):
     """
     Transcripts a video file to a specified destination.
 
     Parameters:
         destination (str): The destination directory used to find the video file,
             and to store the transcription file.
-        domain (str): The domain name used to construct the download URL
-
-    Raises:
-        VideoNotFoundError: If the video file does not exist.
+        domain (str): The domain name used to construct the download URL.
+        video_url (str): The video URL to transcript.
     """
 
-    video = Video.objects.get(directory=destination)
+    video, _ = Video.objects.get_or_create(
+        directory=destination,
+        defaults={
+            "state": VideoState.PUBLISHED,
+        },
+    )
 
-    return create_transcription_job(video=video, domain=domain)
+    transcript_args = {"video": video, "domain": domain}
+    if video_url:
+        transcript_args["video_url"] = video_url
+    return create_transcription_job(**transcript_args)

--- a/src/django_peertube_runner_connector/utils/job_handlers/transcription_job_handler.py
+++ b/src/django_peertube_runner_connector/utils/job_handlers/transcription_job_handler.py
@@ -65,7 +65,7 @@ class TranscriptionJobHandler(AbstractJobHandler):
         video.decrease_job_info(VideoJobInfoColumnType.PENDING_TRANSCRIPT)
 
     # pylint: disable=arguments-differ
-    def create(self, video: Video, domain: str):
+    def create(self, video: Video, domain: str, video_url: str = None):
         """Create a transcription job."""
         job_uuid = uuid.uuid4()
 
@@ -81,6 +81,9 @@ class TranscriptionJobHandler(AbstractJobHandler):
                 ),
             },
         }
+
+        if video_url:
+            payload["input"]["videoFileUrl"] = video_url
 
         private_payload = {
             "videoUUID": str(video.uuid),

--- a/src/django_peertube_runner_connector/utils/transcription/job_creation.py
+++ b/src/django_peertube_runner_connector/utils/transcription/job_creation.py
@@ -5,6 +5,9 @@ from django_peertube_runner_connector.utils.job_handlers.transcription_job_handl
 )
 
 
-def create_transcription_job(video: Video, domain: str):
+def create_transcription_job(video: Video, domain: str, video_url: str = None):
     """Create a transcription job for a video."""
-    TranscriptionJobHandler().create(video=video, domain=domain)
+    transcript_args = {"video": video, "domain": domain}
+    if video_url:
+        transcript_args["video_url"] = video_url
+    TranscriptionJobHandler().create(**transcript_args)

--- a/tests/tests_django_peertube_runner_connector/test_transcript.py
+++ b/tests/tests_django_peertube_runner_connector/test_transcript.py
@@ -11,10 +11,17 @@ from django_peertube_runner_connector.transcript import transcript_video
 class TestTranscript(TestCase):
     """Test the transcript file."""
 
-    def test_transcript_video_video_does_not_exist(self):
-        """Should raise a VideoNotFoundError exception."""
-        with self.assertRaises(Video.DoesNotExist):
-            transcript_video("test_directory", "https://example.com")
+    @patch("django_peertube_runner_connector.transcript.create_transcription_job")
+    def test_transcript_video_video_does_not_exist(self, mock_create_transcription_job):
+        """A video should be created if it does not exist."""
+        destination = "test_directory"
+        domain = "https://example.com"
+        transcript_video(destination, domain)
+
+        video = Video.objects.get(directory=destination)
+        self.assertIsNotNone(video)
+
+        mock_create_transcription_job.assert_called_with(video=video, domain=domain)
 
     @patch("django_peertube_runner_connector.transcript.create_transcription_job")
     def test_transcript_video(self, mock_create_transcription_job):
@@ -25,3 +32,19 @@ class TestTranscript(TestCase):
         transcript_video(destination=video.directory, domain=domain)
 
         mock_create_transcription_job.assert_called_with(video=video, domain=domain)
+
+    @patch("django_peertube_runner_connector.transcript.create_transcription_job")
+    def test_transcript_video_with_video_url(self, mock_create_transcription_job):
+        """Should be able to transcribe a video."""
+        video = VideoFactory()
+        domain = "https://example.com"
+
+        transcript_video(
+            destination=video.directory,
+            domain=domain,
+            video_url="https://example.com/video.mp4",
+        )
+
+        mock_create_transcription_job.assert_called_with(
+            video=video, domain=domain, video_url="https://example.com/video.mp4"
+        )

--- a/tests/tests_django_peertube_runner_connector/utils/job_handlers/test_transcription_job_handler.py
+++ b/tests/tests_django_peertube_runner_connector/utils/job_handlers/test_transcription_job_handler.py
@@ -94,6 +94,30 @@ class TestTranscriptionJobHandler(TestCase):
         )
         self.assertEqual(self.video.jobInfo.pendingTranscript, 2)
 
+    def test_create_video_url(self):
+        """Should be able to create a VIDEO_TRANSCRIPTION runner job with a video url."""
+        handler = TranscriptionJobHandler()
+        runner_job = handler.create(self.video, "test_url", "video_url")
+
+        self.video.refresh_from_db()
+        self.assertEqual(runner_job.type, RunnerJobType.VIDEO_TRANSCRIPTION)
+        self.assertEqual(
+            runner_job.payload,
+            {
+                "input": {
+                    "videoFileUrl": "video_url",
+                },
+            },
+        )
+
+        self.assertEqual(
+            runner_job.privatePayload,
+            {
+                "videoUUID": str(self.video.uuid),
+            },
+        )
+        self.assertEqual(self.video.jobInfo.pendingTranscript, 2)
+
     @patch(
         "django_peertube_runner_connector.utils.job_handlers."
         "transcription_job_handler.on_transcription_ended"

--- a/tests/tests_django_peertube_runner_connector/utils/transcription/test_job_creation.py
+++ b/tests/tests_django_peertube_runner_connector/utils/transcription/test_job_creation.py
@@ -26,3 +26,22 @@ class TranscriptionJobCreationTestCase(TestCase):
         create_transcription_job(video=video, domain=domain)
 
         mocked_class.create.assert_called_with(video=video, domain=domain)
+
+    @patch(
+        "django_peertube_runner_connector.utils.transcription."
+        "job_creation.TranscriptionJobHandler"
+    )
+    def test_create_transcription_jobs_video_url(self, mock_job_handler):
+        """Should call TranscriptionJobHandler to create transcription jobs.
+        Should pass the video_url to the handler.
+        """
+        mocked_class = Mock()
+        mock_job_handler.return_value = mocked_class
+        video = VideoFactory()
+        domain = "example.com"
+
+        create_transcription_job(video=video, domain=domain, video_url="video_url")
+
+        mocked_class.create.assert_called_with(
+            video=video, domain=domain, video_url="video_url"
+        )


### PR DESCRIPTION
As we want to transcript video that were not transcoded by peertube, we want to use public video url.