### PR TITLE
🔧(admin) allow to search the job uuid in the admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Allow to search the job uuid in the admin
+
 ### Fixed
 
 - Fix concurrency when runners accepts the same job
+
 
 ## [0.8.0] - 2024-09-05
 

--- a/src/django_peertube_runner_connector/admin.py
+++ b/src/django_peertube_runner_connector/admin.py
@@ -57,7 +57,7 @@ class RunnerJobAdmin(admin.ModelAdmin):
         "updatedAt",
     )
 
-    search_fields = ("type", "state")
+    search_fields = ("type", "state", "uuid")
     list_filter = ("type", "state")
 
 


### PR DESCRIPTION
Searching a job in the admin on the UUID is not allowed and most of the time it is the only information we have in a log to find it. We allow to search on it.