### PR TITLE
♻️(jobs) do no transcode in resolution higher than one enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Do no transcode in resolution higher than one enabled
+
 ## [0.11.0] - 2024-11-04
 
 ### Added

--- a/src/django_peertube_runner_connector/utils/resolutions.py
+++ b/src/django_peertube_runner_connector/utils/resolutions.py
@@ -5,6 +5,36 @@ from django.conf import settings
 from django_peertube_runner_connector.models import VideoResolution
 
 
+AVAILABLE_RESOLUTIONS = [
+    resolution.value
+    for resolution in [
+        VideoResolution.H_NOVIDEO,
+        VideoResolution.H_144P,
+        VideoResolution.H_240P,
+        VideoResolution.H_360P,
+        VideoResolution.H_480P,
+        VideoResolution.H_720P,
+        VideoResolution.H_1080P,
+        VideoResolution.H_1440P,
+        VideoResolution.H_4K,
+    ]
+]
+
+
+def _get_config_resolutions():
+    """Return a map of resolutions enabled in the settings."""
+    return {
+        "144p": settings.TRANSCODING_RESOLUTIONS_144P,
+        "240p": settings.TRANSCODING_RESOLUTIONS_240P,
+        "360p": settings.TRANSCODING_RESOLUTIONS_360P,
+        "480p": settings.TRANSCODING_RESOLUTIONS_480P,
+        "720p": settings.TRANSCODING_RESOLUTIONS_720P,
+        "1080p": settings.TRANSCODING_RESOLUTIONS_1080P,
+        "1440p": settings.TRANSCODING_RESOLUTIONS_1440P,
+        "2160p": settings.TRANSCODING_RESOLUTIONS_2160P,
+    }
+
+
 def to_even(num: int):
     """Return the next even number."""
     if is_odd(num):
@@ -18,6 +48,24 @@ def is_odd(num: int):
     return num % 2 != 0
 
 
+def compute_max_resolution_to_transcode(
+    input_resolution: int,
+):
+    """Compute the maximum resolution to transcode."""
+    config_resolutions = _get_config_resolutions()
+    available_resolutions = sorted(AVAILABLE_RESOLUTIONS, reverse=True)
+
+    for resolution in available_resolutions:
+        if not config_resolutions.get(f"{resolution}p", None):
+            continue
+        if input_resolution < resolution:
+            continue
+
+        return resolution
+
+    return VideoResolution.H_NOVIDEO
+
+
 def compute_resolutions_to_transcode(
     input_resolution: int,
     include_input: bool,
@@ -25,35 +73,10 @@ def compute_resolutions_to_transcode(
     has_audio: bool,
 ):
     """Compute the possible resolutions to transcode related to settings."""
-    config_resolutions = {
-        "144p": settings.TRANSCODING_RESOLUTIONS_144P,
-        "240p": settings.TRANSCODING_RESOLUTIONS_240P,
-        "360p": settings.TRANSCODING_RESOLUTIONS_360P,
-        "480p": settings.TRANSCODING_RESOLUTIONS_480P,
-        "720p": settings.TRANSCODING_RESOLUTIONS_720P,
-        "1080p": settings.TRANSCODING_RESOLUTIONS_1080P,
-        "1440p": settings.TRANSCODING_RESOLUTIONS_1440P,
-        "2160p": settings.TRANSCODING_RESOLUTIONS_2160P,
-    }
+    config_resolutions = _get_config_resolutions()
 
     resolutions_enabled = set()
-
-    available_resolutions = [
-        resolution.value
-        for resolution in [
-            VideoResolution.H_NOVIDEO,
-            VideoResolution.H_144P,
-            VideoResolution.H_240P,
-            VideoResolution.H_360P,
-            VideoResolution.H_480P,
-            VideoResolution.H_720P,
-            VideoResolution.H_1080P,
-            VideoResolution.H_1440P,
-            VideoResolution.H_4K,
-        ]
-    ]
-
-    for resolution in available_resolutions:
+    for resolution in AVAILABLE_RESOLUTIONS:
         if not config_resolutions.get(f"{resolution}p", None):
             continue
         if input_resolution < resolution:

--- a/src/django_peertube_runner_connector/utils/transcoding/job_creation.py
+++ b/src/django_peertube_runner_connector/utils/transcoding/job_creation.py
@@ -18,6 +18,7 @@ from django_peertube_runner_connector.utils.job_handlers.vod_hls_transcoding_job
     VODHLSTranscodingJobHandler,
 )
 from django_peertube_runner_connector.utils.resolutions import (
+    compute_max_resolution_to_transcode,
     compute_resolutions_to_transcode,
 )
 
@@ -127,7 +128,9 @@ def create_transcoding_jobs(
         else get_video_stream_fps(probe)
     )
 
-    max_resolution = DEFAULT_AUDIO_RESOLUTION if is_audio_file(probe) else resolution
+    max_resolution = compute_max_resolution_to_transcode(
+        DEFAULT_AUDIO_RESOLUTION if is_audio_file(probe) else resolution
+    )
 
     fps = compute_output_fps(input_fps, max_resolution)
 

--- a/tests/tests_django_peertube_runner_connector/utils/test_resolutions.py
+++ b/tests/tests_django_peertube_runner_connector/utils/test_resolutions.py
@@ -3,6 +3,7 @@
 from django.test import TestCase, override_settings
 
 from django_peertube_runner_connector.utils.resolutions import (
+    compute_max_resolution_to_transcode,
     compute_resolutions_to_transcode,
     is_odd,
     to_even,
@@ -69,3 +70,25 @@ class ResolutionsTestCase(TestCase):
             has_audio=False,
         )
         self.assertEqual(resolutions, [240, 360, 480, 720])
+
+    def test_compute_max_resolution_to_transcode(self):
+        """Should return the maximum resolution to transcode."""
+
+        # Max enabled resolution is 720. So for an input resolution higher than 720,
+        # the max resolution to transcode is 720.
+        resolution = compute_max_resolution_to_transcode(input_resolution=1080)
+        self.assertEqual(resolution, 720)
+
+        # Max enabled resolution is 720. So for an input resolution equal to 720,
+        resolution = compute_max_resolution_to_transcode(input_resolution=720)
+        self.assertEqual(resolution, 720)
+
+        # Max enabled resolution is 720 but the input resolution is 540. So the
+        # next lower should be used and it is 480.
+        resolution = compute_max_resolution_to_transcode(input_resolution=540)
+        self.assertEqual(resolution, 480)
+
+        # Max enabled resolution is 720, the input resolution is 480. 480 is an enabled
+        # resolution so it should be used
+        resolution = compute_max_resolution_to_transcode(input_resolution=480)
+        self.assertEqual(resolution, 480)

--- a/tests/tests_django_peertube_runner_connector/views/video/test_transcode_video.py
+++ b/tests/tests_django_peertube_runner_connector/views/video/test_transcode_video.py
@@ -65,12 +65,12 @@ class TranscodeVideoAPITest(TestCase):
             )
             self.assertEqual(response.status_code, 200)
 
-            self.assertEqual(RunnerJob.objects.count(), 3)
+            self.assertEqual(RunnerJob.objects.count(), 2)
             self.assertEqual(
                 RunnerJob.objects.filter(
                     type=RunnerJobType.VOD_HLS_TRANSCODING
                 ).count(),
-                3,
+                2,
             )
             self.assertEqual(
                 RunnerJob.objects.filter(state=RunnerJobState.PENDING).count(), 1
@@ -79,7 +79,7 @@ class TranscodeVideoAPITest(TestCase):
                 RunnerJob.objects.filter(
                     state=RunnerJobState.WAITING_FOR_PARENT_JOB
                 ).count(),
-                2,
+                1,
             )
 
             list_dir, _ = video_storage.listdir("")

--- a/tests/tests_django_peertube_runner_connector/views/video/test_upload_video.py
+++ b/tests/tests_django_peertube_runner_connector/views/video/test_upload_video.py
@@ -53,12 +53,12 @@ class UploadVideoAPITest(TestCase):
 
             self.assertEqual(response.status_code, 200)
 
-            self.assertEqual(RunnerJob.objects.count(), 3)
+            self.assertEqual(RunnerJob.objects.count(), 2)
             self.assertEqual(
                 RunnerJob.objects.filter(
                     type=RunnerJobType.VOD_HLS_TRANSCODING
                 ).count(),
-                3,
+                2,
             )
             self.assertEqual(
                 RunnerJob.objects.filter(state=RunnerJobState.PENDING).count(), 1
@@ -67,7 +67,7 @@ class UploadVideoAPITest(TestCase):
                 RunnerJob.objects.filter(
                     state=RunnerJobState.WAITING_FOR_PARENT_JOB
                 ).count(),
-                2,
+                1,
             )
 
             list_dir, _ = video_storage.listdir("")


### PR DESCRIPTION
The max resolution to transcode was not computed using the resolutions enabled. So the max resolution can be higher than the max resolution enabled. Now the max resolution is computes based on resolutions available and enabled.